### PR TITLE
CLDR-18469 Change long alt names for zh_Hans and zh_Hant

### DIFF
--- a/common/main/en.xml
+++ b/common/main/en.xml
@@ -705,10 +705,10 @@ annotations.
 			<language type="zh" alt="long">Mandarin Chinese</language>
 			<language type="zh" alt="menu">Chinese, Mandarin</language>
 			<language type="zh_Hans">Simplified Chinese</language>
-			<language type="zh_Hans" alt="long">Simplified Mandarin Chinese</language>
+			<language type="zh_Hans" alt="long">Mandarin Chinese (Simplified)</language>
 			<language type="zh_Hans" alt="menu">Chinese, Mandarin (Simplified)</language>
 			<language type="zh_Hant">Traditional Chinese</language>
-			<language type="zh_Hant" alt="long">Traditional Mandarin Chinese</language>
+			<language type="zh_Hant" alt="long">Mandarin Chinese (Traditional)</language>
 			<language type="zh_Hant" alt="menu">Chinese, Mandarin (Traditional)</language>
 			<language type="zu">Zulu</language>
 			<language type="zun">Zuni</language>


### PR DESCRIPTION
matching Mark's suggestion in CLDR-11834, 
following the style of
> English // en if alone
> English (UK)
> English (US) // en if there is another region mentioned for en in the list

CLDR-18469

- [ x ] This PR completes the ticket.

<!--
Thank you for your pull request.
Please see https://cldr.unicode.org/index/process for general
information on contributing to CLDR.

1. Make sure the ticket is filed at
https://unicode-org.atlassian.net/projects/CLDR/
2. Update the PR title and first line of this
message to include the ticket ID (CLDR-_____)
3. You will be automatically asked to sign the contributors’
license before the PR is accepted.
- sign: https://cla-assistant.io/unicode-org/cldr
- license: https://www.unicode.org/copyright.html#License
-->

ALLOW_MANY_COMMITS=true
